### PR TITLE
Disable SGX tests when local_dev is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ etc/
 keys/
 keystores/
 ss_out/
+Secure-Signer/*
+
+# Can't keep empty folders but need it for tests not to break.
+# So this file is kept here as a place holder.
+!Secure-Signer/.__occlum_status
 
 # Avoid adding consensus spec files to repo.
 tests/consensus-spec-tests/

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,11 @@ etc/
 keys/
 keystores/
 ss_out/
-Secure-Signer/
+Secure-Signer/*
+
+# Avoid adding consensus spec files to repo.
+tests/consensus-spec-tests/
+tests/*rc*.gz
+
+# Preferences
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ etc/
 keys/
 keystores/
 ss_out/
-Secure-Signer/*
 
 # Avoid adding consensus spec files to repo.
 tests/consensus-spec-tests/

--- a/Secure-Signer/.__occlum_status
+++ b/Secure-Signer/.__occlum_status
@@ -1,0 +1,1 @@
+running

--- a/Secure-Signer/.gitignore
+++ b/Secure-Signer/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/Secure-Signer/.gitignore
+++ b/Secure-Signer/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/conf/secure-signer-rust-config.yaml
+++ b/conf/secure-signer-rust-config.yaml
@@ -4,4 +4,4 @@ targets:
   - target: /bin
     copy:
       - files:
-        - /root/secure-signer/target/x86_64-unknown-linux-musl/release/secure-signer
+        - ../target/x86_64-unknown-linux-musl/release/secure-signer


### PR DESCRIPTION
These commits disable SGX-specific tests when local_dev env variable is set. It also fixes the issue with not having the Secure-Signer folder in the repo by having a blank placeholder. Other small change is to use relative paths for the occlum conf file so that the signer folder can be moved by devs in their file system without breaking the build.