### PR TITLE
Complete message for signature with Puffer's `validator_index`

### DIFF
--- a/src/client/mock/guardian.rs
+++ b/src/client/mock/guardian.rs
@@ -92,7 +92,7 @@ impl GuardianClientTrait for MockGuardianClient {
 
     async fn validate_custody(
         &self,
-        request: crate::enclave::types::ValidateCustodyRequest,
+        _request: crate::enclave::types::ValidateCustodyRequest,
     ) -> anyhow::Result<crate::enclave::types::ValidateCustodyResponse> {
         match self.validate_custody_responses.lock().unwrap().pop_front() {
             Some(res) => Ok(res),

--- a/src/client/tests/mod.rs
+++ b/src/client/tests/mod.rs
@@ -67,6 +67,7 @@ async fn registration_flow_succeeds() {
         mrenclave,
         mrsigner,
         verify_remote_attestation,
+        validator_index: 0
     };
 
     // Guardian validates they received custody
@@ -129,6 +130,7 @@ async fn test_cli_keygen_verified_by_guardians() {
         mrenclave: "".to_string(),
         mrsigner: "".to_string(),
         verify_remote_attestation,
+        validator_index: 0
     };
 
     // Guardian validates they received custody

--- a/src/enclave/guardian/mod.rs
+++ b/src/enclave/guardian/mod.rs
@@ -1,13 +1,15 @@
-use ethers::signers::{LocalWallet, Signer};
 use log::info;
 use sha3::Digest;
 pub mod handlers;
+use crate::eth2::eth_types::{BLSSignature, ValidatorIndex};
 use anyhow::{anyhow, bail, Result};
 use blsttc::PublicKeySet;
+use ethers::{
+    core::types::U256,
+    signers::{LocalWallet, Signer},
+};
 use libsecp256k1::SecretKey as EthSecretKey;
 use ssz::Encode;
-
-use crate::eth2::eth_types::{BLSSignature, ValidatorIndex};
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct KeygenWithBlockhashRequest {
@@ -46,7 +48,7 @@ pub fn attest_new_eth_key_with_blockhash(
 }
 
 pub async fn verify_and_sign_custody_received(
-    request: crate::enclave::types::ValidateCustodyRequest
+    request: crate::enclave::types::ValidateCustodyRequest,
 ) -> Result<crate::enclave::types::ValidateCustodyResponse> {
     // Read enclave's eth secret key
     let Ok(guardian_enclave_sk) = crate::crypto::eth_keys::fetch_eth_key(
@@ -199,7 +201,7 @@ async fn approve_custody(
 
     // validatorIndex, pubKey, withdrawalCredentials, signature, depositDataRoot
     let msg = ethers::abi::encode(&[
-        ethers::abi::Token::Bytes(validator_index.to_be_bytes().to_vec()),
+        ethers::abi::Token::Uint(U256::from(validator_index.clone())),
         ethers::abi::Token::Bytes(
             keygen_payload
                 .public_key_set()?

--- a/src/enclave/types.rs
+++ b/src/enclave/types.rs
@@ -1,5 +1,6 @@
 use crate::io::remote_attestation::AttestationEvidence;
 use crate::{crypto::eth_keys, strip_0x_prefix};
+use crate::eth2::eth_types::ValidatorIndex;
 use anyhow::{bail, Result};
 use blsttc::{PublicKey as BlsPublicKey, PublicKeySet};
 use ecies::{PublicKey as EthPublicKey, SecretKey as EthSecretKey};
@@ -137,6 +138,7 @@ pub struct ValidateCustodyRequest {
     pub mrenclave: String,
     pub mrsigner: String,
     pub verify_remote_attestation: bool,
+    pub validator_index: ValidatorIndex
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Linked to https://github.com/PufferFinance/PufferPool/issues/154

Complete https://github.com/PufferFinance/PufferPool/pull/155 and https://github.com/PufferFinance/coral/pull/24.

Add Puffer's `validator_index` to message ready-to-be-signed by guardians