### PR TITLE
sign voluntary exit now uses epoch from fork version

### DIFF
--- a/src/enclave/guardian/mod.rs
+++ b/src/enclave/guardian/mod.rs
@@ -242,8 +242,8 @@ pub fn sign_voluntary_exit_message(
     );
     let sk = crate::crypto::bls_keys::fetch_bls_sk(&pk_hex)?.secret_key();
 
-    // Sign a VoluntaryExitMessage with Epoch 0
-    let (sig, _root) = sign_vem(sk, 0, req.validator_index, req.fork_info)?;
+    // Sign a VoluntaryExitMessage
+    let (sig, _root) = sign_vem(sk, req.fork_info.epoch, req.validator_index, req.fork_info)?;
 
     Ok(crate::enclave::types::SignExitResponse {
         signature: hex::encode(sig.as_ssz_bytes()),
@@ -471,7 +471,11 @@ mod tests {
         let (resp, g_sks, _mre, _mrs) = setup();
 
         for g_sk in g_sks {
-            assert!(approve_custody(&resp, &g_sk, &0, U256::from_dec_str("1000").unwrap()).await.is_ok());
+            assert!(
+                approve_custody(&resp, &g_sk, &0, U256::from_dec_str("1000").unwrap())
+                    .await
+                    .is_ok()
+            );
         }
     }
 

--- a/src/enclave/types.rs
+++ b/src/enclave/types.rs
@@ -1,6 +1,6 @@
+use crate::eth2::eth_types::ValidatorIndex;
 use crate::io::remote_attestation::AttestationEvidence;
 use crate::{crypto::eth_keys, strip_0x_prefix};
-use crate::eth2::eth_types::ValidatorIndex;
 use anyhow::{bail, Result};
 use blsttc::{PublicKey as BlsPublicKey, PublicKeySet};
 use ecies::{PublicKey as EthPublicKey, SecretKey as EthSecretKey};
@@ -140,7 +140,7 @@ pub struct ValidateCustodyRequest {
     pub mrsigner: String,
     pub verify_remote_attestation: bool,
     pub validator_index: ValidatorIndex,
-    pub vt_burn_offset: U256
+    pub vt_burn_offset: U256,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
I think this is causing a lot of headaches with sign-voluntary-exit