### PR TITLE
add better error handling to clients

### DIFF
--- a/src/client/guardian.rs
+++ b/src/client/guardian.rs
@@ -31,51 +31,79 @@ impl GuardianClientTrait for GuardianClient {
             blockhash: blockhash.to_string(),
         };
 
-        Ok(self
+        let resp = self
             .client
             .post(format!("{}/eth/v1/keygen", self.url))
             .json(&data)
             .send()
-            .await?
-            .json()
-            .await?)
+            .await?;
+
+        let resp_status = resp.status();
+        if !resp_status.is_success() {
+            let body = resp.text().await?;
+            return Err(anyhow::anyhow!(body));
+        }
+
+        let resp_json = resp.json().await?;
+        Ok(resp_json)
     }
 
     async fn list_eth_keys(&self) -> anyhow::Result<crate::enclave::types::ListKeysResponse> {
-        Ok(self
+        let resp = self
             .client
             .get(format!("{}/eth/v1/keygen", self.url))
             .send()
-            .await?
-            .json::<crate::enclave::types::ListKeysResponse>()
-            .await?)
+            .await?;
+
+        let resp_status = resp.status();
+        if !resp_status.is_success() {
+            let body = resp.text().await?;
+            return Err(anyhow::anyhow!(body));
+        }
+
+        let resp_json = resp.json().await?;
+        Ok(resp_json)
     }
 
     async fn validate_custody(
         &self,
         request: crate::enclave::types::ValidateCustodyRequest,
     ) -> anyhow::Result<crate::enclave::types::ValidateCustodyResponse> {
-        Ok(self
+        let resp = self
             .client
             .post(format!("{}/guardian/v1/validate-custody", self.url))
             .json(&request)
             .send()
-            .await?
-            .json()
-            .await?)
+            .await?;
+
+        let resp_status = resp.status();
+        if !resp_status.is_success() {
+            let body = resp.text().await?;
+            return Err(anyhow::anyhow!(body));
+        }
+
+        let resp_json = resp.json().await?;
+        Ok(resp_json)
     }
 
     async fn sign_exit(
         &self,
         request: crate::enclave::types::SignExitRequest,
     ) -> anyhow::Result<crate::enclave::types::SignExitResponse> {
-        Ok(self
+        let resp = self
             .client
             .post(format!("{}/guardian/v1/sign-exit", self.url))
             .json(&request)
             .send()
-            .await?
-            .json()
-            .await?)
+            .await?;
+
+        let resp_status = resp.status();
+        if !resp_status.is_success() {
+            let body = resp.text().await?;
+            return Err(anyhow::anyhow!(body));
+        }
+
+        let resp_json = resp.json().await?;
+        Ok(resp_json)
     }
 }

--- a/src/enclave/guardian/mod.rs
+++ b/src/enclave/guardian/mod.rs
@@ -471,7 +471,11 @@ mod tests {
         let (resp, g_sks, _mre, _mrs) = setup();
 
         for g_sk in g_sks {
-            assert!(approve_custody(&resp, &g_sk, &0, U256::from_dec_str("1000").unwrap()).await.is_ok());
+            assert!(
+                approve_custody(&resp, &g_sk, &0, U256::from_dec_str("1000").unwrap())
+                    .await
+                    .is_ok()
+            );
         }
     }
 

--- a/src/enclave/types.rs
+++ b/src/enclave/types.rs
@@ -1,6 +1,6 @@
+use crate::eth2::eth_types::ValidatorIndex;
 use crate::io::remote_attestation::AttestationEvidence;
 use crate::{crypto::eth_keys, strip_0x_prefix};
-use crate::eth2::eth_types::ValidatorIndex;
 use anyhow::{bail, Result};
 use blsttc::{PublicKey as BlsPublicKey, PublicKeySet};
 use ecies::{PublicKey as EthPublicKey, SecretKey as EthSecretKey};
@@ -140,7 +140,7 @@ pub struct ValidateCustodyRequest {
     pub mrsigner: String,
     pub verify_remote_attestation: bool,
     pub validator_index: ValidatorIndex,
-    pub vt_burn_offset: U256
+    pub vt_burn_offset: U256,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Ensure theres no error before trying to decode json.
This will provide better error message to coral/reef instead of a generic `Invalid Json` error