### PR TITLE
Complete SignExitResponse

### DIFF
--- a/src/enclave/guardian/mod.rs
+++ b/src/enclave/guardian/mod.rs
@@ -243,10 +243,11 @@ pub fn sign_voluntary_exit_message(
     let sk = crate::crypto::bls_keys::fetch_bls_sk(&pk_hex)?.secret_key();
 
     // Sign a VoluntaryExitMessage with Epoch 0
-    let (sig, _root) = sign_vem(sk, 0, req.validator_index, req.fork_info)?;
+    let (sig, root) = sign_vem(sk, 0, req.validator_index, req.fork_info)?;
 
     Ok(crate::enclave::types::SignExitResponse {
         signature: hex::encode(sig.as_ssz_bytes()),
+        msg: hex::encode(root),
     })
 }
 

--- a/src/enclave/guardian/mod.rs
+++ b/src/enclave/guardian/mod.rs
@@ -247,7 +247,7 @@ pub fn sign_voluntary_exit_message(
 
     Ok(crate::enclave::types::SignExitResponse {
         signature: hex::encode(sig.as_ssz_bytes()),
-        msg: hex::encode(root),
+        message: hex::encode(root),
     })
 }
 

--- a/src/enclave/types.rs
+++ b/src/enclave/types.rs
@@ -295,6 +295,7 @@ impl SignExitRequest {
 #[serde(rename_all = "camelCase")]
 pub struct SignExitResponse {
     pub signature: String,
+    pub msg: String,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]

--- a/src/enclave/types.rs
+++ b/src/enclave/types.rs
@@ -295,7 +295,7 @@ impl SignExitRequest {
 #[serde(rename_all = "camelCase")]
 pub struct SignExitResponse {
     pub signature: String,
-    pub msg: String,
+    pub message: String,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]


### PR DESCRIPTION
Simply returns msg in `SignExitResponse` to avoid recomputing it to verify aggregated sig  